### PR TITLE
Allow passing kwargs without specifying headers

### DIFF
--- a/aiohttp_sse_client/client.py
+++ b/aiohttp_sse_client/client.py
@@ -88,7 +88,9 @@ class EventSource:
         self._orginal_reconnection_time = reconnection_time
         self._max_connect_retry = max_connect_retry
         self._last_event_id = ''
-        self._kwargs = kwargs or {'headers': MultiDict()}
+        self._kwargs = kwargs
+        if 'headers' not in self._kwargs:
+            self._kwargs['headers'] = MultiDict()
 
         self._event_id = ''
         self._event_type = ''


### PR DESCRIPTION
Previously, passing any kwargs seemed to cause an error if a 'headers' parameter was not also provided. This small change ensures that the default behavior happens when kwargs is used.