### PR TITLE
Fix pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ matrix:
   fast_finish: true
   include:
   - python: '3.6'
-    env: TOXENV=py36
+    env: 
+      - TOXENV=py36
+      - CRYPTOGRAPHY_DONT_BUILD_RUST=1
   - python: '3.7'
     env: TOXENV=py37
   - python: '3.8'
@@ -12,7 +14,9 @@ cache:
   directories:
   - "$HOME/.cache/pip"
 language: python
-before_install: python -m pip install --upgrade pip
+before_install: 
+  - python -m pip install --upgrade pip
+  - pip --version
 install: pip install -U tox-travis
 script: travis_wait 30 tox --develop
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   directories:
   - "$HOME/.cache/pip"
 language: python
+before_install: python -m pip install --upgrade pip
 install: pip install -U tox-travis
 script: travis_wait 30 tox --develop
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ matrix:
   include:
   - python: '3.6'
     env: TOXENV=py36
-    before_install: 
-      - python -m pip install --upgrade pip
-      - pip install "cryptography>=3,<3.4" 
   - python: '3.7'
     env: TOXENV=py37
   - python: '3.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ matrix:
   fast_finish: true
   include:
   - python: '3.6'
-    env: 
-      - TOXENV=py36
-      - CRYPTOGRAPHY_DONT_BUILD_RUST=1
+    env: TOXENV=py36
+    before_install: 
+      - python -m pip install --upgrade pip
+      - pip install cryptography<3.4 
   - python: '3.7'
     env: TOXENV=py37
   - python: '3.8'
@@ -14,9 +15,6 @@ cache:
   directories:
   - "$HOME/.cache/pip"
 language: python
-before_install: 
-  - python -m pip install --upgrade pip
-  - pip --version
 install: pip install -U tox-travis
 script: travis_wait 30 tox --develop
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     env: TOXENV=py36
     before_install: 
       - python -m pip install --upgrade pip
-      - pip install cryptography<3.4 
+      - pip install "cryptography>=3,<3.4" 
   - python: '3.7'
     env: TOXENV=py37
   - python: '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,6 @@ commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}
 
-
+[testenv]
+commands_pre =
+    pip install "cryptography>=3,<3.4"

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,6 @@ commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}
 
-[testenv]
+[testenv:py36]
 commands_pre =
     pip install "cryptography>=3,<3.4"

--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,6 @@ commands =
     py.test --basetemp={envtmpdir}
 
 [testenv:py36]
-commands_pre =
-    pip install "cryptography>=3,<3.4"
+deps =
+    cryptography>=3,<3.4
+    -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
Try to fix the pipeline error

```
  running build_rust
  
      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation.html for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq.html
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation.html#rust
      5) If you are experiencing issues with Rust for *this release only* you may
         set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
      =============================DEBUG ASSISTANCE=============================
  
  error: Can not find Rust compiler
```